### PR TITLE
Improved Performance by optimising the canvas.

### DIFF
--- a/src/elements/canvas.ts
+++ b/src/elements/canvas.ts
@@ -21,6 +21,7 @@ export class Canvas extends LitElement {
 
   private pointerDown = false;
   private previewColor: 'primary' | 'secondary' = 'primary';
+  private lastPointerEventTime = 0;
 
   static get styles(): CSSResultGroup {
     return css`
@@ -167,15 +168,23 @@ export class Canvas extends LitElement {
     clearCanvas(this.drawingContext);
     this.drawingContext.document.dirty = false;
     updateContext(this);
+    document.addEventListener('pointermove', (event) => this.throttledPointerMove(event));
 
-    document.addEventListener('pointermove', (event) =>
-      this.onPointerMove(event),
-    );
     document.addEventListener('pointerup', (event) => this.onPointerUp(event));
 
     this.dispatchEvent(
       new CustomEvent('canvas-ready', { bubbles: true, composed: true }),
     );
+    
+  }
+
+  throttledPointerMove(event: PointerEvent): void {
+    const currentTime = Date.now();
+    if (currentTime - this.lastPointerEventTime < 8) { // Throttle mouse polling rate to ~125hz 1000/125 = 8
+      return;
+    }
+    this.lastPointerEventTime = currentTime;
+    this.onPointerMove(event);
   }
 
   getToolEventArgs(


### PR DESCRIPTION
## Issue

When using a mouse with polling rate greater than 500hz significant lag is observed.

## Description

This merge request introduces performance optimizations to the canvas code by throttling pointer move events, As many gaming mouse nowadays provides more than 125 hz which is overkill for paint, keeping a uppercap of 125 hz gives a significant performance boost.  

## Changes

- Added a throttled event handler `throttledPointerMove` for `pointermove` events to prevent excessive updates to the canvas.

## Testing

Maximum lag was observed when erasing fully colored canvas. So I choose it as a benchmark.
- Verified that the rendering updates occur at a reasonable rate without sacrificing responsiveness.
-  Ensured that the canvas performance is improved, especially during high-frequency drawing operations.
- Tested the canvas functionality with various drawing operations.

## Results
- 125hz Tweaked for performance.
[125hz.webm](https://github.com/christianliebel/paint/assets/68627196/23adecc9-93f2-4e49-9181-40b5d094029c)
- 250hz Tweaked for performance. 
[250hz.webm](https://github.com/christianliebel/paint/assets/68627196/5edf9ed1-ed24-4fd6-aa4e-1969d235c844)
- 500hz Orignal.
[500hz.webm](https://github.com/christianliebel/paint/assets/68627196/42b5270f-d428-49cf-9aaf-5d4574a638f8)
1000hz Orignal.
[1000hz.webm](https://github.com/christianliebel/paint/assets/68627196/69c03543-31e5-401e-b95f-eeabd6871686)

## System specs

Processor	11th Gen Intel(R) Core(TM) i5-11400H @ 2.70GHz
Installed RAM	16.0 GB (15.7 GB usable)
System type	64-bit operating system
Gpu                 3050 laptop.


