### PR TITLE
feat: support cancelling operations with Esc or the opposite mouse button

### DIFF
--- a/src/elements/canvas.ts
+++ b/src/elements/canvas.ts
@@ -2,6 +2,7 @@ import { css, CSSResultGroup, html, LitElement, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { DRAWING_CONTEXT } from '../data/drawing-context';
 import { clearCanvas } from '../helpers/clear-canvas';
+import { clearContext } from '../helpers/clear-context';
 import { evaluateTextToolbarVisibility } from '../helpers/evaluate-text-toolbar-visibility';
 import { updateContext } from '../helpers/update-context';
 import type { DrawingContext } from '../models/drawing-context';
@@ -190,12 +191,22 @@ export class Canvas extends LitElement {
 
     document.addEventListener('pointerup', (event) => this.onPointerUp(event));
 
+    document.addEventListener('keydown', (event) => this.onKeyDown(event));
+
     this.dispatchEvent(
       new CustomEvent('canvas-ready', { bubbles: true, composed: true }),
     );
   }
 
   throttledPointerMove(event: PointerEvent): void {
+    // Pressing the opposite mouse button while drawing cancels the operation.
+    // Chorded button presses arrive as pointermove events, so this must be
+    // checked before throttling drops the event.
+    if (this.pointerDown && this.isOppositeButtonPressed(event)) {
+      this.cancelOperation();
+      return;
+    }
+
     const currentTime = Date.now();
     if (currentTime - this.lastPointerEventTime < 8) {
       // Throttle mouse polling rate to ~125hz 1000/125 = 8
@@ -232,6 +243,10 @@ export class Canvas extends LitElement {
     evaluateTextToolbarVisibility(this.drawingContext);
     updateContext(this);
 
+    // Stale hover previews (e.g., the brush shape or eraser outline) must not
+    // become part of the operation that is committed on pointer up.
+    clearContext(this.drawingContext.previewContext);
+
     if (this.tool?.onPointerDown) {
       const { x, y } = this.getCoordinates(event);
       this.tool.onPointerDown(...this.getToolEventArgs(x, y));
@@ -255,7 +270,9 @@ export class Canvas extends LitElement {
       );
     }
 
-    if (this.tool?.onPointerHover) {
+    // Hover previews would clear the preview canvas and therefore wipe the
+    // operation in progress, so they are suspended while the pointer is down.
+    if (!this.pointerDown && this.tool?.onPointerHover) {
       this.tool.onPointerHover(...this.getToolEventArgs(x, y));
     }
 
@@ -274,6 +291,15 @@ export class Canvas extends LitElement {
       this.tool.onPointerUp(...this.getToolEventArgs(x, y));
     }
 
+    // Tools draw exclusively onto the preview canvas. The result is committed
+    // to the main canvas here. Tools that use the preview canvas for UI
+    // overlays only (e.g., Select, Text) clear it in their onPointerUp.
+    const { context, previewCanvas, previewContext } = this.drawingContext;
+    if (context && previewCanvas) {
+      context.drawImage(previewCanvas, 0, 0);
+    }
+    clearContext(previewContext);
+
     this.drawingContext.history?.commit();
 
     // This position is important for correct preview behavior
@@ -284,6 +310,62 @@ export class Canvas extends LitElement {
     if (this.tool?.onPointerHover) {
       this.tool.onPointerHover(...this.getToolEventArgs(x, y));
     }
+  }
+
+  onKeyDown(event: KeyboardEvent): void {
+    if (event.key !== 'Escape') {
+      return;
+    }
+
+    // Don't interfere with open dialogs (e.g., Attributes, Custom Zoom).
+    const inDialog = event
+      .composedPath()
+      .some(
+        (target) =>
+          target instanceof HTMLElement &&
+          target.tagName.toLowerCase().startsWith('paint-dialog'),
+      );
+    if (inDialog) {
+      return;
+    }
+
+    if (this.pointerDown) {
+      this.cancelOperation();
+      return;
+    }
+
+    if (this.drawingContext.text.active) {
+      this.drawingContext.text.active = false;
+      evaluateTextToolbarVisibility(this.drawingContext);
+      updateContext(this);
+      return;
+    }
+
+    if (this.drawingContext.selection) {
+      this.drawingContext.selection = null;
+      this.dispatchEvent(
+        new CustomEvent('area', { bubbles: true, composed: true }),
+      );
+      updateContext(this);
+    }
+  }
+
+  cancelOperation(): void {
+    if (!this.pointerDown) {
+      return;
+    }
+
+    this.pointerDown = false;
+    this.tool?.onCancel?.(this.drawingContext);
+    // Tools draw exclusively onto the preview canvas, so discarding the
+    // preview is all it takes to cancel the operation.
+    clearContext(this.drawingContext.previewContext);
+  }
+
+  isOppositeButtonPressed({ buttons }: PointerEvent): boolean {
+    // previewColor is 'primary' when drawing started with the left button.
+    const oppositeButtonMask = this.previewColor === 'primary' ? 2 : 1;
+    return (buttons & oppositeButtonMask) !== 0;
   }
 
   onPointerEnter(): void {

--- a/src/models/tool.ts
+++ b/src/models/tool.ts
@@ -39,4 +39,10 @@ export interface Tool {
     drawingContext?: DrawingContext,
     color?: ToolColor,
   ): void;
+  /**
+   * Called when an operation in progress is cancelled (e.g., by pressing Esc
+   * or the opposite mouse button while drawing). Tools should reset transient
+   * state here. The canvas clears the preview and restores the main canvas.
+   */
+  onCancel?(drawingContext?: DrawingContext): void;
 }

--- a/src/tools/airbrush.ts
+++ b/src/tools/airbrush.ts
@@ -13,8 +13,8 @@ export class Airbrush implements Tool {
     drawingContext: DrawingContext,
     color: ToolColor,
   ): void {
-    if (drawingContext.context) {
-      drawingContext.context.fillStyle = color.stroke.value;
+    if (drawingContext.previewContext) {
+      drawingContext.previewContext.fillStyle = color.stroke.value;
     }
 
     this.currentPosition = { x, y };
@@ -22,8 +22,8 @@ export class Airbrush implements Tool {
     this.intervalHandle = setInterval(() => this.spray(drawingContext), 30);
   }
 
-  spray({ airbrushSize, context }: DrawingContext): void {
-    if (this.currentPosition && context) {
+  spray({ airbrushSize, previewContext }: DrawingContext): void {
+    if (this.currentPosition && previewContext) {
       const radius = Math.floor(airbrushSize / 2);
       const { x, y } = this.currentPosition;
       const points: Point[] = [];
@@ -32,7 +32,7 @@ export class Airbrush implements Tool {
       for (let i = 0; i < 10; i++) {
         const index = Math.round(Math.random() * (points.length - 1));
         const { x, y } = points[index];
-        context.fillRect(x, y, 1, 1);
+        previewContext.fillRect(x, y, 1, 1);
       }
     }
   }
@@ -45,6 +45,14 @@ export class Airbrush implements Tool {
   }
 
   onPointerUp(): void {
+    this.stopSpraying();
+  }
+
+  onCancel(): void {
+    this.stopSpraying();
+  }
+
+  private stopSpraying(): void {
     if (typeof this.intervalHandle !== 'undefined') {
       clearInterval(this.intervalHandle);
       this.intervalHandle = this.currentPosition = undefined;

--- a/src/tools/brush.ts
+++ b/src/tools/brush.ts
@@ -25,12 +25,12 @@ export class BrushTool implements Tool {
   onPointerDown(
     x: number,
     y: number,
-    { brush, context }: DrawingContext,
+    { brush, previewContext }: DrawingContext,
     color: ToolColor,
   ): void {
-    if (context) {
-      context.fillStyle = color.stroke.value;
-      this.drawBrush(x, y, brush, context);
+    if (previewContext) {
+      previewContext.fillStyle = color.stroke.value;
+      this.drawBrush(x, y, brush, previewContext);
       this.previous = { x, y };
     }
   }
@@ -38,15 +38,15 @@ export class BrushTool implements Tool {
   onPointerMove(
     x: number,
     y: number,
-    { brush, context }: DrawingContext,
+    { brush, previewContext }: DrawingContext,
   ): void {
-    if (context) {
+    if (previewContext) {
       let previousBresenham = { ...this.previous };
       line(this.previous.x, this.previous.y, x, y, (x, y) => {
         // Position difference is required for forward lines to ensure
         // continuous drawing.
         const diff = { x: x - previousBresenham.x, y: y - previousBresenham.y };
-        this.drawBrush(x, y, brush, context, diff);
+        this.drawBrush(x, y, brush, previewContext, diff);
         previousBresenham = { x, y };
       });
       this.previous = { x, y };

--- a/src/tools/ellipse.ts
+++ b/src/tools/ellipse.ts
@@ -15,23 +15,21 @@ export class EllipseTool implements Tool {
   onPointerMove(
     x: number,
     y: number,
-    { fillStyle, canvas, previewContext }: DrawingContext,
+    { fillStyle, previewContext }: DrawingContext,
     color: ToolColor,
   ): void {
-    if (canvas && previewContext) {
-      this.drawEllipse(x, y, fillStyle, color, previewContext, previewContext);
+    if (previewContext) {
+      this.drawEllipse(x, y, fillStyle, color, previewContext);
     }
   }
 
   onPointerUp(
     x: number,
     y: number,
-    { fillStyle, canvas, context, previewContext }: DrawingContext,
+    drawingContext: DrawingContext,
     color: ToolColor,
   ): void {
-    if (canvas && context && previewContext) {
-      this.drawEllipse(x, y, fillStyle, color, context, previewContext);
-    }
+    this.onPointerMove(x, y, drawingContext, color);
   }
 
   private drawEllipse(
@@ -40,9 +38,8 @@ export class EllipseTool implements Tool {
     fillStyle: FillStyle,
     color: ToolColor,
     targetContext: CanvasRenderingContext2D,
-    previewContext: CanvasRenderingContext2D,
   ): void {
-    clearContext(previewContext);
+    clearContext(targetContext);
 
     const ellipsePixels: Point[] = [];
     ellipseRect(this.startPosition.x, this.startPosition.y, x, y, (x, y) => {

--- a/src/tools/eraser.ts
+++ b/src/tools/eraser.ts
@@ -51,17 +51,17 @@ export class EraserTool implements Tool {
   private handleEraser(
     x: number,
     y: number,
-    { context, eraserSize, colors }: DrawingContext,
+    { context, previewContext, eraserSize, colors }: DrawingContext,
     color: ToolColor,
   ) {
-    if (!context) {
+    if (!context || !previewContext) {
       return;
     }
 
     if (color.stroke.key === 'primary') {
       // Normal eraser
-      context.fillStyle = colors.secondary;
-      context.fillRect(...this.getFillRectArgs(x, y, eraserSize));
+      previewContext.fillStyle = colors.secondary;
+      previewContext.fillRect(...this.getFillRectArgs(x, y, eraserSize));
     } else {
       // Color eraser
       const { r: matchR, g: matchG, b: matchB } = hexToRgb(colors.primary);
@@ -92,7 +92,7 @@ export class EraserTool implements Tool {
         }
       }
 
-      context.putImageData(imageData, rectX, rectY);
+      previewContext.putImageData(imageData, rectX, rectY);
     }
   }
 

--- a/src/tools/fill.ts
+++ b/src/tools/fill.ts
@@ -6,15 +6,15 @@ export class FillTool implements Tool {
   onPointerDown(
     x: number,
     y: number,
-    { canvas, context }: DrawingContext,
+    { canvas, context, previewContext }: DrawingContext,
     color: ToolColor,
   ): void {
-    if (canvas && context) {
+    if (canvas && context && previewContext) {
       const floodFill = new FloodFill(
         context.getImageData(0, 0, canvas.width, canvas.height),
       );
       floodFill.fill(color.stroke.value, x, y, 0);
-      context.putImageData(floodFill.imageData, 0, 0);
+      previewContext.putImageData(floodFill.imageData, 0, 0);
     }
   }
 }

--- a/src/tools/line.ts
+++ b/src/tools/line.ts
@@ -11,45 +11,38 @@ export class LineTool implements Tool {
   onPointerDown(
     x: number,
     y: number,
-    { previewContext, context }: DrawingContext,
+    { previewContext }: DrawingContext,
     color: ToolColor,
   ): void {
-    if (previewContext && context) {
+    if (previewContext) {
       this.startPosition = { x, y };
-      previewContext.fillStyle = context.fillStyle = color.stroke.value;
+      previewContext.fillStyle = color.stroke.value;
     }
   }
 
   onPointerMove(
     x: number,
     y: number,
-    { previewContext, canvas, lineWidth }: DrawingContext,
+    { previewContext, lineWidth }: DrawingContext,
   ): void {
-    if (canvas && previewContext) {
-      this.drawLine(x, y, previewContext, previewContext, lineWidth);
+    if (previewContext) {
+      this.drawLine(x, y, previewContext, lineWidth);
     }
   }
 
-  onPointerUp(
-    x: number,
-    y: number,
-    { previewContext, context, canvas, lineWidth }: DrawingContext,
-  ): void {
-    if (previewContext && context && canvas) {
-      this.drawLine(x, y, context, previewContext, lineWidth);
-    }
+  onPointerUp(x: number, y: number, drawingContext: DrawingContext): void {
+    this.onPointerMove(x, y, drawingContext);
   }
 
   drawLine(
     x: number,
     y: number,
-    targetContext: CanvasRenderingContext2D,
     previewContext: CanvasRenderingContext2D,
     lineWidth: number,
   ): void {
     clearContext(previewContext);
     line(x, y, this.startPosition.x, this.startPosition.y, (x, y) => {
-      drawCircle(x, y, lineWidth, targetContext);
+      drawCircle(x, y, lineWidth, previewContext);
     });
   }
 }

--- a/src/tools/pencil.ts
+++ b/src/tools/pencil.ts
@@ -9,19 +9,23 @@ export class PencilTool implements Tool {
   onPointerDown(
     x: number,
     y: number,
-    { context }: DrawingContext,
+    { previewContext }: DrawingContext,
     color: ToolColor,
   ): void {
-    if (context) {
-      context.fillStyle = color.stroke.value;
-      context.fillRect(x, y, 1, 1);
+    if (previewContext) {
+      previewContext.fillStyle = color.stroke.value;
+      previewContext.fillRect(x, y, 1, 1);
       this.previous = { x, y };
     }
   }
 
-  onPointerMove(x: number, y: number, { context }: DrawingContext): void {
+  onPointerMove(
+    x: number,
+    y: number,
+    { previewContext }: DrawingContext,
+  ): void {
     line(this.previous.x, this.previous.y, x, y, (x, y) => {
-      context?.fillRect(x, y, 1, 1);
+      previewContext?.fillRect(x, y, 1, 1);
     });
     this.previous = { x, y };
   }

--- a/src/tools/rectangle.ts
+++ b/src/tools/rectangle.ts
@@ -14,51 +14,32 @@ export class RectangleTool implements Tool {
   onPointerMove(
     x: number,
     y: number,
-    { canvas, lineWidth, fillStyle, previewContext }: DrawingContext,
+    { lineWidth, fillStyle, previewContext }: DrawingContext,
     color: ToolColor,
   ): void {
-    if (canvas && previewContext) {
-      this.drawRectangle(
-        x,
-        y,
-        previewContext,
-        previewContext,
-        fillStyle,
-        lineWidth,
-        color,
-      );
+    if (previewContext) {
+      this.drawRectangle(x, y, previewContext, fillStyle, lineWidth, color);
     }
   }
 
   onPointerUp(
     x: number,
     y: number,
-    { canvas, context, lineWidth, fillStyle, previewContext }: DrawingContext,
+    drawingContext: DrawingContext,
     color: ToolColor,
   ): void {
-    if (canvas && context && previewContext) {
-      this.drawRectangle(
-        x,
-        y,
-        context,
-        previewContext,
-        fillStyle,
-        lineWidth,
-        color,
-      );
-    }
+    this.onPointerMove(x, y, drawingContext, color);
   }
 
   drawRectangle(
     x: number,
     y: number,
     targetContext: CanvasRenderingContext2D,
-    previewContext: CanvasRenderingContext2D,
     fillStyle: { fill: boolean; stroke: boolean },
     lineWidth: number,
     color: ToolColor,
   ): void {
-    clearContext(previewContext);
+    clearContext(targetContext);
 
     const x1 = Math.min(this.startPosition.x, x);
     const x2 = Math.max(this.startPosition.x, x);

--- a/src/tools/select.ts
+++ b/src/tools/select.ts
@@ -28,6 +28,12 @@ export class SelectTool implements Tool {
     dispatchAreaEvent(this.startPosition, { x, y }, element);
   }
 
+  onCancel(drawingContext?: DrawingContext): void {
+    drawingContext?.element?.dispatchEvent(
+      new CustomEvent('area', { bubbles: true, composed: true }),
+    );
+  }
+
   onPointerUp(x: number, y: number, drawingContext: DrawingContext): void {
     const { element, previewContext } = drawingContext;
     clearContext(previewContext);

--- a/src/tools/text.ts
+++ b/src/tools/text.ts
@@ -23,6 +23,12 @@ export class TextTool implements Tool {
     dispatchAreaEvent(this.startPosition, { x, y }, element);
   }
 
+  onCancel(drawingContext?: DrawingContext): void {
+    drawingContext?.element?.dispatchEvent(
+      new CustomEvent('area', { bubbles: true, composed: true }),
+    );
+  }
+
   onPointerUp(x: number, y: number, drawingContext: DrawingContext): void {
     clearContext(drawingContext.previewContext);
 


### PR DESCRIPTION
## What

Adds the ability to cancel an in-progress drawing operation:

- **Esc** while dragging cancels the current operation (shape previews, freehand strokes, fills, airbrush).
- **Opposite mouse button** while drawing also cancels: right-click during a left-button drag, left-click during a right-button drag. Chorded presses arrive as `pointermove` events with a changed `buttons` bitmask, so this is detected before the move throttle.
- **Esc** while idle closes an active text box (committing it, same as clicking outside) or dismisses an active selection.
- Esc originating inside an open dialog (e.g. Attributes) is ignored.

## How

The enabling refactor: **all drawing tools now render exclusively onto the preview canvas.** The canvas blits the preview onto the main canvas once on pointer up, right before `history.commit()`. Cancelling therefore just discards the preview — no canvas state restore needed.

- Pencil, Brush, Airbrush, Eraser, and Fill write to `previewContext` instead of `context` (Eraser's color-eraser mode and Fill still *read* from the main canvas).
- The shape tools (Line, Rectangle, Ellipse) lost their dual-target draw paths; `onPointerUp` now just redraws the final preview at the release position and the canvas commits it.
- The preview is cleared on pointer down so stale hover shapes (brush cursor, eraser outline) can't be committed, and hover previews are suspended while the pointer is down so they can't wipe the stroke in progress.
- New optional `Tool.onCancel` hook: the Airbrush stops its spray interval, Select/Text clear the status-bar area text.
- Select and Text are unaffected by the commit blit — they use the preview for UI overlays only and already clear it in their own `onPointerUp`.

A nice side effect: the main canvas is only ever mutated at commit points, so the undo history is correct by construction — including for Fill, which previously painted on pointer down.

## Reviewer notes

- Behavior change: while dragging, the brush-shape/eraser-outline hover indicator is hidden (the stroke itself shows the position); it reappears on release.
- Pre-existing issue spotted but not addressed here: `TextTool.onPointerUp` mutates `text.x/y` before its minimum-size early return, which can misplace text when pointer down/up happen within one Lit render frame.

## Testing

`tsc`, ESLint, and Jest pass. Manually exercised every tool in the running app: commit on release, Esc cancel, and opposite-button cancel for all drawing tools; airbrush interval stops on cancel; right-button brush strokes use the secondary color without committing the stale primary hover shape; undo/redo unaffected; selection rectangle and text previews never leak onto the canvas; text commits on click-away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)