### PR TITLE
test: add unit tests for hexToRgb and fillEllipse helpers

### DIFF
--- a/src/helpers/fill-ellipse.spec.ts
+++ b/src/helpers/fill-ellipse.spec.ts
@@ -1,0 +1,148 @@
+import type { Point } from '../models/point';
+import { fillEllipse } from './fill-ellipse';
+
+/**
+ * Collects every pixel produced by fillEllipse for the given parameters.
+ */
+function collect(xc: number, yc: number, a: number, b: number): Point[] {
+  const points: Point[] = [];
+  fillEllipse(xc, yc, a, b, (point) => points.push(point));
+  return points;
+}
+
+function key({ x, y }: Point): string {
+  return `${x},${y}`;
+}
+
+function keysOf(points: Point[]): string[] {
+  return points.map(key);
+}
+
+describe('fillEllipse', () => {
+  describe('exact output for known shapes', () => {
+    test('a radius-2 circle renders the expected 13-pixel disc', () => {
+      const expected = [
+        [0, -2],
+        [-1, -1],
+        [0, -1],
+        [1, -1],
+        [-2, 0],
+        [-1, 0],
+        [0, 0],
+        [1, 0],
+        [2, 0],
+        [-1, 1],
+        [0, 1],
+        [1, 1],
+        [0, 2],
+      ].map(([x, y]) => `${x},${y}`);
+
+      expect(keysOf(collect(0, 0, 2, 2)).sort()).toEqual(expected.sort());
+    });
+
+    test('an offset ellipse is rendered around its centre', () => {
+      const expected = [
+        [5, 3],
+        [3, 4],
+        [4, 4],
+        [5, 4],
+        [6, 4],
+        [7, 4],
+        [3, 5],
+        [4, 5],
+        [5, 5],
+        [6, 5],
+        [7, 5],
+        [3, 6],
+        [4, 6],
+        [5, 6],
+        [6, 6],
+        [7, 6],
+        [5, 7],
+      ].map(([x, y]) => `${x},${y}`);
+
+      expect(keysOf(collect(5, 5, 3, 2)).sort()).toEqual(expected.sort());
+    });
+  });
+
+  describe('degenerate shapes', () => {
+    test('b = 0 draws a single horizontal line of width 2a + 1', () => {
+      const points = collect(0, 0, 3, 0);
+
+      expect(points).toHaveLength(7);
+      expect(points.every(({ y }) => y === 0)).toBe(true);
+      expect(points.map(({ x }) => x).sort((m, n) => m - n)).toEqual([
+        -3, -2, -1, 0, 1, 2, 3,
+      ]);
+    });
+
+    test('a = 0 draws a single vertical line of height 2b + 1', () => {
+      const points = collect(0, 0, 0, 3);
+
+      expect(points).toHaveLength(7);
+      expect(points.every(({ x }) => x === 0)).toBe(true);
+      expect(points.map(({ y }) => y).sort((m, n) => m - n)).toEqual([
+        -3, -2, -1, 0, 1, 2, 3,
+      ]);
+    });
+
+    test('a = 0 and b = 0 draws exactly the centre pixel', () => {
+      expect(collect(4, 7, 0, 0)).toEqual([{ x: 4, y: 7 }]);
+    });
+
+    test('a radius-1 circle produces a thin vertical run', () => {
+      // The reference algorithm collapses a radius-1 circle to a 3-pixel
+      // vertical run rather than a plus/3x3 block. This pins that behaviour.
+      expect(keysOf(collect(0, 0, 1, 1)).sort()).toEqual(
+        ['0,-1', '0,0', '0,1'].sort(),
+      );
+    });
+  });
+
+  describe('geometric invariants', () => {
+    const cases: ReadonlyArray<[number, number, number, number]> = [
+      [0, 0, 1, 1],
+      [0, 0, 2, 2],
+      [0, 0, 3, 3],
+      [5, 5, 3, 2],
+      [10, 4, 5, 4],
+      [2, 9, 4, 6],
+      [0, 0, 3, 0],
+      [0, 0, 0, 3],
+    ];
+
+    test.each(cases)(
+      'ellipse at (%i,%i) with a=%i b=%i keeps every pixel inside its bounding box',
+      (xc, yc, a, b) => {
+        for (const { x, y } of collect(xc, yc, a, b)) {
+          expect(x).toBeGreaterThanOrEqual(xc - a);
+          expect(x).toBeLessThanOrEqual(xc + a);
+          expect(y).toBeGreaterThanOrEqual(yc - b);
+          expect(y).toBeLessThanOrEqual(yc + b);
+        }
+      },
+    );
+
+    test.each(cases)(
+      'ellipse at (%i,%i) with a=%i b=%i is duplicate-free and symmetric about both axes',
+      (xc, yc, a, b) => {
+        const points = collect(xc, yc, a, b);
+        const keys = keysOf(points);
+        const set = new Set(keys);
+
+        // No pixel is emitted twice.
+        expect(set.size).toBe(keys.length);
+
+        for (const { x, y } of points) {
+          // Mirror across the vertical axis x = xc.
+          expect(set.has(`${2 * xc - x},${y}`)).toBe(true);
+          // Mirror across the horizontal axis y = yc.
+          expect(set.has(`${x},${2 * yc - y}`)).toBe(true);
+        }
+
+        // The centre pixel is always painted.
+        expect(set.has(`${xc},${yc}`)).toBe(true);
+      },
+    );
+  });
+});

--- a/src/helpers/hex-to-rgb.spec.ts
+++ b/src/helpers/hex-to-rgb.spec.ts
@@ -1,0 +1,39 @@
+import { hexToRgb } from './hex-to-rgb';
+
+describe('hexToRgb', () => {
+  test('parses black', () => {
+    expect(hexToRgb('#000000')).toEqual({ r: 0, g: 0, b: 0 });
+  });
+
+  test('parses white', () => {
+    expect(hexToRgb('#FFFFFF')).toEqual({ r: 255, g: 255, b: 255 });
+  });
+
+  test.each([
+    ['#FF0000', { r: 255, g: 0, b: 0 }],
+    ['#00FF00', { r: 0, g: 255, b: 0 }],
+    ['#0000FF', { r: 0, g: 0, b: 255 }],
+  ])('parses the primary channel of %s', (hex, expected) => {
+    expect(hexToRgb(hex)).toEqual(expected);
+  });
+
+  test('parses a mixed colour with per-channel values', () => {
+    // #808040 is one of the default palette entries.
+    expect(hexToRgb('#808040')).toEqual({ r: 128, g: 128, b: 64 });
+  });
+
+  test('parses the smallest non-zero value per channel', () => {
+    expect(hexToRgb('#010203')).toEqual({ r: 1, g: 2, b: 3 });
+  });
+
+  test('is case-insensitive for the hex digits', () => {
+    expect(hexToRgb('#ff8040')).toEqual(hexToRgb('#FF8040'));
+    expect(hexToRgb('#ff8040')).toEqual({ r: 255, g: 128, b: 64 });
+  });
+
+  test('reads only the first three channels and ignores trailing characters', () => {
+    // Documents the contract: an #RRGGBBAA string keeps R, G and B and
+    // drops the alpha byte rather than throwing.
+    expect(hexToRgb('#12345678')).toEqual({ r: 0x12, g: 0x34, b: 0x56 });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Jest unit tests for two previously untested pure helpers, partially addressing #33 ("Add unit tests").

- `hexToRgb` (`src/helpers/hex-to-rgb.ts`): color parsing used by the eraser's color-replacement path. 9 tests covering channel parsing, case-insensitivity, and boundary bytes.
- `fillEllipse` (`src/helpers/fill-ellipse.ts`): the integer ellipse-fill algorithm used by the airbrush tool. 22 tests covering exact output for known shapes, degenerate cases (a=0, b=0, radius 1), and geometric invariants (in-bounds, dual-axis symmetry, duplicate-free, and the centre pixel).

Test-only, no runtime or source changes. Specs are co-located next to their sources, matching the existing `view-bitmap.spec.ts`.

`npx jest` -> 3 suites, 32 tests passed. Prettier and ESLint are clean.

Relates to #33.
